### PR TITLE
Allow Console IO Injection

### DIFF
--- a/app/config.php
+++ b/app/config.php
@@ -3,14 +3,24 @@
 use function DI\object;
 use SuperBlog\Model\ArticleRepository;
 use SuperBlog\Persistence\InMemoryArticleRepository;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\ArgvInput;
+
 
 return [
     // Bind an interface to an implementation
     ArticleRepository::class => object(InMemoryArticleRepository::class),
+
+    // Bind console interfaces to an implementation
+    OutputInterface::class => object(ConsoleOutput::class),
+    InputInterface::class => object(ArgvInput::class),
 
     // Configure Twig
     Twig_Environment::class => function () {
         $loader = new Twig_Loader_Filesystem(__DIR__ . '/../src/SuperBlog/Views');
         return new Twig_Environment($loader);
     },
+
 ];

--- a/console.php
+++ b/console.php
@@ -2,6 +2,7 @@
 
 use SuperBlog\Model\ArticleRepository;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputInterface;
 
 $container = require __DIR__ . '/app/bootstrap.php';
 
@@ -32,4 +33,7 @@ $app->command('articles', function (OutputInterface $output, ArticleRepository $
 // That allows to use dependency injection in the constructor
 $app->command('article [id]', 'SuperBlog\Command\ArticleDetailCommand');
 
-$app->run();
+$app->run(
+    $container->get(InputInterface::class),
+    $container->get(OutputInterface::class)
+);


### PR DESCRIPTION
This is a great demo, but it was both confusing and frustrating not being able to resolve the console IO Interfaces. This adds the defaults to `app/config.php` and updates `console.php` to use. It really feels like a shortcoming in `Symfony\Components\Console`, but this seems to be the easiest way to patch.