### PR TITLE
upgrade twig from 1 to 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,9 @@
     "name": "php-di/demo",
     "license": "MIT",
     "type": "project",
+    "scripts": {
+        "serve": "@php -S localhost:8000 -t web/"
+    },
     "autoload": {
         "psr-4": {
             "SuperBlog\\": "src/SuperBlog/"
@@ -11,7 +14,7 @@
         "php": ">=7.0",
         "php-di/php-di": "^6.0",
         "nikic/fast-route": "~0.5.0",
-        "twig/twig": "^1.18",
-        "mnapoli/silly": "^1.7"
+        "mnapoli/silly": "^1.7",
+        "twig/twig": "^3.2"
     }
 }

--- a/src/SuperBlog/Controller/ArticleController.php
+++ b/src/SuperBlog/Controller/ArticleController.php
@@ -3,7 +3,7 @@
 namespace SuperBlog\Controller;
 
 use SuperBlog\Model\ArticleRepository;
-use Twig_Environment;
+use Twig\Environment;
 
 class ArticleController
 {
@@ -17,7 +17,7 @@ class ArticleController
      */
     private $twig;
 
-    public function __construct(ArticleRepository $repository, Twig_Environment $twig)
+    public function __construct(ArticleRepository $repository, Environment $twig)
     {
         $this->repository = $repository;
         $this->twig = $twig;

--- a/src/SuperBlog/Controller/HomeController.php
+++ b/src/SuperBlog/Controller/HomeController.php
@@ -3,7 +3,7 @@
 namespace SuperBlog\Controller;
 
 use SuperBlog\Model\ArticleRepository;
-use Twig_Environment;
+use Twig\Environment;
 
 class HomeController
 {
@@ -17,7 +17,7 @@ class HomeController
      */
     private $twig;
 
-    public function __construct(ArticleRepository $repository, Twig_Environment $twig)
+    public function __construct(ArticleRepository $repository, Environment $twig)
     {
         $this->repository = $repository;
         $this->twig = $twig;


### PR DESCRIPTION
when i try this on my local, twig throwing an exception.
dunno what happend, but upgrade twig from 1 to 3 fixed it on php 7.4
```
[Thu Jan  7 18:50:48 2021] [::1]:40018 [500]: GET / - Uncaught LogicException: You must set a loader first. in /var/www/refer/riset-framework-php/php-di-example/vendor/twig/twig/src/Environment.php:819
Stack trace:
#0 /var/www/refer/riset-framework-php/php-di-example/vendor/twig/twig/src/Environment.php(351): Twig\Environment->getLoader()
#1 /var/www/refer/riset-framework-php/php-di-example/vendor/twig/twig/src/Environment.php(445): Twig\Environment->getTemplateClass()
#2 /var/www/refer/riset-framework-php/php-di-example/vendor/twig/twig/src/Environment.php(423): Twig\Environment->loadTemplate()
#3 /var/www/refer/riset-framework-php/php-di-example/vendor/twig/twig/src/Environment.php(384): Twig\Environment->load()
#4 /var/www/refer/riset-framework-php/php-di-example/src/SuperBlog/Controller/HomeController.php(34): Twig\Environment->render()
#5 [internal function]: SuperBlog\Controller\HomeController->__invoke()
#6 /var/www/refer/riset-framework-php/php-di-example/vendor/php-di/invoker/src/Invoker.php(75): call_user_func_array()
#7 /var/www/refer/riset-framework- in /var/www/refer/riset-framework-php/php-di-example/vendor/twig/twig/src/Environment.php on line 819
```
